### PR TITLE
Run chown as root in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ ARG AZLINUX_BASE_VERSION=3.13-pythonnginx
 
 FROM quay.io/cdis/amazonlinux-base:${AZLINUX_BASE_VERSION} AS base
 
+USER root
+
 ENV appname=peregrine
 
 WORKDIR /${appname}
 
 RUN chown -R gen3:gen3 /${appname}
+
+USER gen3
 
 # Builder stage
 FROM base AS builder


### PR DESCRIPTION
Ensure ownership changes succeed by switching to root before setting permissions and then reverting to the gen3 user. Adds USER root before creating and chown'ing /${appname}, runs RUN chown -R gen3:gen3 /${appname}, and adds USER gen3 so subsequent stages run as the non-root user.